### PR TITLE
update user signup to use the user id

### DIFF
--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -131,7 +131,7 @@ export function AppWrapper({ children }) {
                 AuthWithFacebook,
                 profilePicture,
                 isSignUpSuccessful,
-                setIsSignUpSuccessful
+                setIsSignUpSuccessful,
             }}
         >
             {children}

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -130,6 +130,8 @@ export function AppWrapper({ children }) {
                 AuthWithGoogle,
                 AuthWithFacebook,
                 profilePicture,
+                isSignUpSuccessful,
+                setIsSignUpSuccessful
             }}
         >
             {children}

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -177,7 +177,7 @@ const Login = () => {
                                         buttonSize='md'
                                     />
                                 </button>
-                                <Link href='/signUp/signUp'>
+                                <Link href='/signUp'>
                                     <Button
                                         buttonText={t("login.signUp")}
                                         buttonSize='md'

--- a/src/pages/signUp/index.jsx
+++ b/src/pages/signUp/index.jsx
@@ -9,7 +9,7 @@ import {
     updateProfile,
 } from "firebase/auth";
 import { auth } from "@/util/firebase";
-import { collection, addDoc } from "firebase/firestore";
+import { collection, setDoc, doc } from "firebase/firestore";
 import { db } from "@/util/firebase";
 import Layout from "@/layout/Layout";
 import Link from "next/link";
@@ -63,7 +63,7 @@ export default function SignUp() {
 
             // Save user information in Firestore
             const userCollection = collection(db, "users");
-            await addDoc(userCollection, {
+            await setDoc(doc(userCollection, user.uid), {
                 firstname: formData.firstname,
                 lastname: formData.lastname,
                 email: formData.email,


### PR DESCRIPTION
## Changes Made

- Update user signup to use the user id as the document id when creating the collection in firestore
- Change the signup page name :  signUp.jsx => index.jsx
- Fix the thank you page issue

fix #79 

# Related Issue

- Resolve #79